### PR TITLE
add HW-3 files

### DIFF
--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -9,6 +9,12 @@ spec:
    containers:
    - name: web
      image: kk74/homework:0.0.1
+     readinessProbe:
+       httpGet:
+         path: /index.html
+         port: 80
+     livenessProbe:
+         tcpSocket: { port: 8000 }
      volumeMounts:
      - name: app
        mountPath: /app

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -4,10 +4,9 @@ RUN adduser -u 1001 -D appuser
 
 RUN mkdir /app
 RUN chmod -R 777 /app
-COPY ./index.html /app/homework.html
 
 EXPOSE 8000
 
 USER appuser
 
-CMD [ "python", "-m", "http.server", "8000" ]
+CMD [ "python", "-m", "http.server", "8000", "--directory", "/app" ]

--- a/kubernetes-networks/README.md
+++ b/kubernetes-networks/README.md
@@ -1,0 +1,84 @@
+# Проверки в POD
+
+*readnessProbe* - проверка после успешного прохождения которой, Pod готов принимать и обслуживать трафик. Состояние определяется в describe: Conditions (Ready: True)
+
+*livenessProbe* - предназначена для определения условия когда требуется перезагрузка пода.
+
+В случае проверки процесса - это не имеет смысла, ввиду того что процесс может быть активным, но не принимать соединения.
+Имеет смысл - если процесс может "упасть".
+
+# Deployment
+
+Состояние Pod оказывает влияние на Deployment: Conditions - строчка Available. Корректная работа Deployment: Status=True для Available и Progressing.
+
+Используя разные значения maxSurge, maxUnavailable можно релизовывать стратегию Deployment: Rolling Update (постепенная замена старых, постепенное удаление новых). Recreate (все поды удаляются, новые создаются)
+
+# Service
+
+ClusterIP обеспечивает подключение к конечным Pod сервиса чрез одну "точку входа", однако при этом каждый под будет обслуживать запросы случайным образом (простейшая балансировка).
+
+Под капотом: iptables или ipvs.
+
+# LoadBalancer и Ingress
+
+MetalLB - обеспечивает выделение адресов из пула для service, к которым можно получить доступ "снаружи", с небольшой доработкок: нужно добавить подсеть на сетевой интерфейс.
+
+#  DNS через MetalLB
+minikube start --addons=metallb --addons=ingress --extra-config kube-proxy.mode=ipvs --extra-config kube-proxy.ipvs.strictARP=true --driver=hyperkit --cpus 2 --memory 4096
+cd coredns
+kubectl apply -f ../metallb-config.yaml
+minikube ip
+<MK_IP>
+sudo route add 172.17.252.0/24 <MK_IP>
+kubectl apply -f dns-lb.yaml
+dig @172.17.252.11 ns.dns.cluster.local
+
+# Ingress для Dashboard
+`minikube start --addons=metallb --addons=ingress --extra-config kube-proxy.mode=ipvs --extra-config kube-proxy.ipvs.strictARP=true --driver=hyperkit --cpus 2 --memory 4096`
+
+Применяем манифест для стандартного dashboard
+`kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml`
+
+Применяем манифест для ингресс
+`kubectl apply -f dashboard-ingress.yaml`
+
+Применяем манифесты для управления аккаунтом и получения токена
+`kubectl apply -f service-account.yaml`
+
+`kubectl apply -f binding.yaml`
+
+`kubectl -n kubernetes-dashboard create token admin-user`
+
+Получаем IP-адрес для доступа
+`kubectl -n kubernetes-dashboard get ingress | grep "dashboard-ingress" | awk -F' ' '{ print $4}'` 
+
+**Для проверки открыть ссылку https://<IP-FROM-LAST-COMMAND>/dashboard/
+Использовать Token - результат вывода команды  create token...**
+
+# CANARY
+
+стартуем minikube
+`minikube start --addons=metallb --addons=ingress --extra-config kube-proxy.mode=ipvs --extra-config kube-proxy.ipvs.strictARP=true --driver=hyperkit --cpus 2 --memory 4096`
+
+Применяем манифест для деплоя v 1
+`kubectl apply -f app-v1.yaml`
+Применяем манифест ingress для 1 версии
+`kubectl apply -f canary-ingress-v1.yaml`
+Получаем адрес, по которому доступен ingress 
+`kubectl get ingress | grep "my-app-v1" | awk -F' ' '{ print $4}'`
+Смотрим статус pod. Ждем Running 
+`kubectl get pods`
+Получаем
+`curl http://адрес ingress`
+
+Применяем манифест для деплоя v 2
+`kubectl apply -f app-v2.yaml`
+Canary ingress  
+`kubectl apply -f canary-ingress.yaml`
+Получаем адрес, по которому доступен ingress 
+`kubectl get ingress | grep "canary" | awk -F' ' '{ print $4}'`
+Смотрим статус pod. Ждем Running 
+`kubectl get pods`
+Получаем
+`curl http://адрес ingress`
+

--- a/kubernetes-networks/canary/app-v1.yaml
+++ b/kubernetes-networks/canary/app-v1.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app-v1
+  labels:
+    app: my-app
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    app: my-app
+    version: v1.0.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app-v1
+  labels:
+    app: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+      version: v1.0.0
+  template:
+    metadata:
+      labels:
+        app: my-app
+        version: v1.0.0
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9101"
+    spec:
+      containers:
+      - name: my-app
+        image: containersol/k8s-deployment-strategies
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: probe
+          containerPort: 8086
+        env:
+        - name: VERSION
+          value: v1.0.0
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: probe
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: probe
+          periodSeconds: 5

--- a/kubernetes-networks/canary/app-v2.yaml
+++ b/kubernetes-networks/canary/app-v2.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-app-v2
+  labels:
+    app: my-app
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    app: my-app
+    version: v2.0.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-app-v2
+  labels:
+    app: my-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-app
+      version: v2.0.0
+  template:
+    metadata:
+      labels:
+        app: my-app
+        version: v2.0.0
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9101"
+    spec:
+      containers:
+      - name: my-app
+        image: containersol/k8s-deployment-strategies
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: probe
+          containerPort: 8086
+        env:
+        - name: VERSION
+          value: v2.0.0
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: probe
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: probe
+          periodSeconds: 5

--- a/kubernetes-networks/canary/canary-ingress-v1.yaml
+++ b/kubernetes-networks/canary/canary-ingress-v1.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-app-v1
+  namespace: default
+  labels:
+    app: my-app
+#  annotations:
+#    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: my-app-v1
+            port: 
+              number: 80
+

--- a/kubernetes-networks/canary/canary-ingress-v2.yaml
+++ b/kubernetes-networks/canary/canary-ingress-v2.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-app-v2
+  namespace: default
+  labels:
+    app: my-app
+#  annotations:
+#    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: my-app-v2
+            port: 
+              number: 80
+

--- a/kubernetes-networks/canary/canary-ingress.yaml
+++ b/kubernetes-networks/canary/canary-ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: canary
+  labels:
+    app: my-app
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "50"
+    nginx.ingress.kubernetes.io/canary-by-header: always
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: my-app-v2
+            port:
+              number: 80
+

--- a/kubernetes-networks/coredns/dns-lb.yaml
+++ b/kubernetes-networks/coredns/dns-lb.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-service-tcp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "key-to-share-dns"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.252.11
+  ports:
+    - name: dnstcp
+      protocol: TCP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-service-udp
+  namespace: kube-system
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "key-to-share-dns"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.252.11
+  ports:
+    - name: dnsudp
+      protocol: UDP
+      port: 53
+      targetPort: 53
+  selector:
+    k8s-app: kube-dns

--- a/kubernetes-networks/dashboard/binding.yaml
+++ b/kubernetes-networks/dashboard/binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admin-user
+  namespace: kubernetes-dashboard

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dashboard-ingress
+  namespace: kubernetes-dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: $1$2
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: Prefix
+        path: /dashboard(/|$)(.*)
+        backend:
+          service:
+            name: kubernetes-dashboard
+            port: 
+              number: 443
+

--- a/kubernetes-networks/dashboard/service-account.yaml
+++ b/kubernetes-networks/dashboard/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 172.17.252.10-172.17.252.20

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+      maxSurge: 0%
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image: kk74/homework:0.0.2
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      initContainers:
+        - name: html-gen
+          image: busybox:musl
+          command: ['sh', '-c', 'wget -O- https://bit.ly/otus-k8s-index-gen | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: Prefix
+        path: /web
+        backend:
+          service:
+            name: web-svc
+            port: 
+              number: 8000
+  ingressClassName: nginx
+

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 81
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ № 3

 - [ x] Основное ДЗ
 - [ x] Задание со *

## Проверки в POD

*readnessProbe* - проверка после успешного прохождения которой, Pod готов принимать и обслуживать трафик. Состояние определяется в describe: Conditions (Ready: True)

*livenessProbe* - предназначена для определения условия когда требуется перезагрузка пода.

В случае проверки процесса - это не имеет смысла, ввиду того что процесс может быть активным, но не принимать соединения.
Имеет смысл - если процесс может "упасть".

## Deployment

Состояние Pod оказывает влияние на Deployment: Conditions - строчка Available. Корректная работа Deployment: Status=True для Available и Progressing.

Используя разные значения maxSurge, maxUnavailable можно релизовывать стратегию Deployment: Rolling Update (постепенная замена старых, постепенное удаление новых). Recreate (все поды удаляются, новые создаются)

## Service

ClusterIP обеспечивает подключение к конечным Pod сервиса чрез одну "точку входа", однако при этом каждый под будет обслуживать запросы случайным образом (простейшая балансировка).

Под капотом: iptables или ipvs.

## LoadBalancer и Ingress

MetalLB - обеспечивает выделение адресов из пула для service, к которым можно получить доступ "снаружи", с небольшой доработкок: нужно добавить подсеть на сетевой интерфейс.

##  DNS через MetalLB
minikube start --addons=metallb --addons=ingress --extra-config kube-proxy.mode=ipvs --extra-config kube-proxy.ipvs.strictARP=true --driver=hyperkit --cpus 2 --memory 4096
cd coredns
kubectl apply -f ../metallb-config.yaml
minikube ip
<MK_IP>
sudo route add 172.17.252.0/24 <MK_IP>
kubectl apply -f dns-lb.yaml
dig @172.17.252.11 ns.dns.cluster.local

## * Ingress для Dashboard
`minikube start --addons=metallb --addons=ingress --extra-config kube-proxy.mode=ipvs --extra-config kube-proxy.ipvs.strictARP=true --driver=hyperkit --cpus 2 --memory 4096`

Применяем манифест для стандартного dashboard
`kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml`

Применяем манифест для ингресс
`kubectl apply -f dashboard-ingress.yaml`

Применяем манифесты для управления аккаунтом и получения токена
`kubectl apply -f service-account.yaml`

`kubectl apply -f binding.yaml`

`kubectl -n kubernetes-dashboard create token admin-user`

Получаем IP-адрес для доступа
`kubectl -n kubernetes-dashboard get ingress | grep "dashboard-ingress" | awk -F' ' '{ print $4}'` 

**Для проверки открыть ссылку https://<IP-FROM-LAST-COMMAND>/dashboard/
Использовать Token - результат вывода команды  create token...**

## * CANARY

стартуем minikube
`minikube start --addons=metallb --addons=ingress --extra-config kube-proxy.mode=ipvs --extra-config kube-proxy.ipvs.strictARP=true --driver=hyperkit --cpus 2 --memory 4096`

Применяем манифест для деплоя v 1
`kubectl apply -f app-v1.yaml`
Применяем манифест ingress для 1 версии
`kubectl apply -f canary-ingress-v1.yaml`
Получаем адрес, по которому доступен ingress 
`kubectl get ingress | grep "my-app-v1" | awk -F' ' '{ print $4}'`
Смотрим статус pod. Ждем Running 
`kubectl get pods`
Получаем
`curl http://адрес ingress`

Применяем манифест для деплоя v 2
`kubectl apply -f app-v2.yaml`
Canary ingress  
`kubectl apply -f canary-ingress.yaml`
Получаем адрес, по которому доступен ingress 
`kubectl get ingress | grep "canary" | awk -F' ' '{ print $4}'`
Смотрим статус pod. Ждем Running 
`kubectl get pods`
Получаем
`curl http://адрес ingress`

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
